### PR TITLE
Issue #2: Sanitize

### DIFF
--- a/__tests__/context.ts
+++ b/__tests__/context.ts
@@ -77,4 +77,23 @@ describe('Job Context Testing', () => {
     expect(error).toBeUndefined()
     expect(res).toEqual([499500, 499500])
   })
+
+  it('should not allow arbitrary code execution in strings', async () => {
+    let error
+    let res
+
+    const evilString = '\';parentPort.postMessage({data: \"Hippity Hoppity, this program is now my property\"});\''
+
+    const ctx = { evilString }
+
+    try {
+      // @ts-ignore
+      res = await job(() => evilString, { ctx })
+    } catch (err) {
+      error = err
+    }
+
+    expect(error).toBeUndefined()
+    expect(res).toEqual(evilString)
+  })
 })

--- a/src/worker-pool.ts
+++ b/src/worker-pool.ts
@@ -83,8 +83,6 @@ class WorkerPool {
         let variable
         switch (typeof config.ctx[key]) {
           case 'string':
-            variable = `'${config.ctx[key]}'`
-            break
           case 'object':
             variable = JSON.stringify(config.ctx[key])
             break


### PR DESCRIPTION
I noticed a part of the guide that mentioned a security issue stemming from string input sanitizing for the `ctx` argument passed to `job`. Link: #2

I was surprised to see that when assigning the string context variable that the only thing that seemed to go on was wrapping the string in a set of single-quotes:
```js
case 'string':
  variable = `'${config.ctx[key]}'`
  break
```
which allows the exploit shown in #2 to occur. This PR simply uses `JSON.stringify` instead, just like it is already done with `object` types to stop someone from doing some quote-related funny-business. I won't claim that this makes everything particularly safe, but it does solve the simple case shown in the issue description. Perhaps the docs can be updated to show how such an exploit could still occur.

This PR also adds a test that checks, and fails on master, but passes on this PR, for allowance of arbitrary code execution in strings passed to the `ctx` argument of `job`.