### PR TITLE
 Fix version comparison issue

### DIFF
--- a/src/worker-pool.ts
+++ b/src/worker-pool.ts
@@ -203,7 +203,7 @@ class WorkerPool {
   }
 
   async teardown(): Promise<void> {
-    if (NODE_VERSION_MAJOR >= 12 && NODE_VERSION_MINOR >= 5) {
+    if (NODE_VERSION_MAJOR > 12 || (NODE_VERSION_MAJOR >= 12 && NODE_VERSION_MINOR >= 5)) {
       const terminationPromises = []
 
       for (const { worker } of this.workers) {


### PR DESCRIPTION
Minor node version shouldn't be tested if the major version is greater than 12